### PR TITLE
refactor start-stop

### DIFF
--- a/lib/src/androidTest/java/com/what3words/ocr/components/W3WOcrMLKitWrapperTest.kt
+++ b/lib/src/androidTest/java/com/what3words/ocr/components/W3WOcrMLKitWrapperTest.kt
@@ -51,11 +51,13 @@ class W3WOcrMLKitWrapperTest {
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, latinTextRecognizer)
 
         //when & wait
+        mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
             mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
+        mlKitWrapper.stop()
 
         //then
         verify(exactly = 1) { what3WordsAndroidWrapper.autosuggest("filled.count.soap") }
@@ -85,11 +87,13 @@ class W3WOcrMLKitWrapperTest {
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, latinTextRecognizer)
 
         //when & wait
+        mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
             mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
+        mlKitWrapper.stop()
 
         //then
         verify(exactly = 1) { what3WordsAndroidWrapper.autosuggest("filled.count.soap") }
@@ -119,11 +123,13 @@ class W3WOcrMLKitWrapperTest {
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, devanagariTextRecognizer)
 
         //when & wait
+        mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
             mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
+        mlKitWrapper.stop()
 
         //then
         verify(exactly = 1) {
@@ -154,11 +160,13 @@ class W3WOcrMLKitWrapperTest {
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, japaneseTextRecognizer)
 
         //when & wait
+        mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
             mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
+        mlKitWrapper.stop()
 
         //then
         verify(exactly = 1) {
@@ -189,11 +197,13 @@ class W3WOcrMLKitWrapperTest {
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, koreanTextRecognizer)
 
         //when & wait
+        mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
             mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
+        mlKitWrapper.stop()
 
         //then
         verify(exactly = 1) {
@@ -219,16 +229,18 @@ class W3WOcrMLKitWrapperTest {
             context.resources,
             com.what3words.ocr.components.test.R.drawable.simple_valid_chinese_3wa
         )
-        val chineseTextRecognizer = ChineseTextRecognizerOptions.Builder().build() 
+        val chineseTextRecognizer = ChineseTextRecognizerOptions.Builder().build()
 
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, chineseTextRecognizer)
 
         //when & wait
+        mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
             mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
+        mlKitWrapper.stop()
 
         //then
         verify(exactly = 1) {

--- a/lib/src/androidTest/java/com/what3words/ocr/components/W3WOcrMLKitWrapperTest.kt
+++ b/lib/src/androidTest/java/com/what3words/ocr/components/W3WOcrMLKitWrapperTest.kt
@@ -46,8 +46,7 @@ class W3WOcrMLKitWrapperTest {
             com.what3words.ocr.components.test.R.drawable.simple_filled_count_soap
         )
 
-        val latinTextRecognizer =
-            TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+        val latinTextRecognizer = TextRecognizerOptions.DEFAULT_OPTIONS
 
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, latinTextRecognizer)
 
@@ -81,8 +80,7 @@ class W3WOcrMLKitWrapperTest {
             com.what3words.ocr.components.test.R.drawable.simple_valid_english_uppercase_3wa
         )
 
-        val latinTextRecognizer =
-            TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+        val latinTextRecognizer = TextRecognizerOptions.DEFAULT_OPTIONS
 
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, latinTextRecognizer)
 
@@ -111,8 +109,7 @@ class W3WOcrMLKitWrapperTest {
             TestData.hindiAutosuggestResponse
         }
 
-        val devanagariTextRecognizer =
-            TextRecognition.getClient(DevanagariTextRecognizerOptions.Builder().build())
+        val devanagariTextRecognizer = DevanagariTextRecognizerOptions.Builder().build()
 
         val bitmapToScan = BitmapFactory.decodeResource(
             context.resources,
@@ -152,8 +149,7 @@ class W3WOcrMLKitWrapperTest {
             context.resources,
             com.what3words.ocr.components.test.R.drawable.simple_valid_japanese_3wa
         )
-        val japaneseTextRecognizer =
-            TextRecognition.getClient(JapaneseTextRecognizerOptions.Builder().build())
+        val japaneseTextRecognizer = JapaneseTextRecognizerOptions.Builder().build()
 
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, japaneseTextRecognizer)
 
@@ -188,8 +184,7 @@ class W3WOcrMLKitWrapperTest {
             context.resources,
             com.what3words.ocr.components.test.R.drawable.simple_valid_korean_3wa
         )
-        val koreanTextRecognizer =
-            TextRecognition.getClient(KoreanTextRecognizerOptions.Builder().build())
+        val koreanTextRecognizer = KoreanTextRecognizerOptions.Builder().build()
 
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, koreanTextRecognizer)
 
@@ -224,8 +219,7 @@ class W3WOcrMLKitWrapperTest {
             context.resources,
             com.what3words.ocr.components.test.R.drawable.simple_valid_chinese_3wa
         )
-        val chineseTextRecognizer =
-            TextRecognition.getClient(ChineseTextRecognizerOptions.Builder().build())
+        val chineseTextRecognizer = ChineseTextRecognizerOptions.Builder().build() 
 
         mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, chineseTextRecognizer)
 

--- a/lib/src/main/java/com/what3words/ocr/components/models/W3WOcrWrapper.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/models/W3WOcrWrapper.kt
@@ -98,14 +98,14 @@ interface W3WOcrWrapper {
     fun dataProvider(): What3WordsAndroidWrapper
 
     /**
+     * This method should be called when wrapper needs to be ready to start scanning i.e: Activity.onCreated
+     **/
+    fun start()
+
+    /**
      * This method should be called when all the work from this wrapper is finished i.e: Activity.onDestroy
      **/
     fun stop()
-
-    /**
-     * This method should be called when wrapper is fully disposed, i.e: App.onDestroy
-     **/
-    fun destroy()
 
     enum class OcrProvider {
         MLKit,

--- a/lib/src/main/java/com/what3words/ocr/components/ui/BaseOcrScanActivity.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/ui/BaseOcrScanActivity.kt
@@ -55,6 +55,11 @@ abstract class BaseOcrScanActivity : ComponentActivity() {
         const val CLOSE_BUTTON_CD_ID = "CLOSE_BUTTON_CD"
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        ocrWrapper.stop()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // we can assume here that is not null due to the checks and exceptions thrown on the Builder.build()
@@ -81,21 +86,9 @@ abstract class BaseOcrScanActivity : ComponentActivity() {
             ?: getString(R.string.scan_state_loading)
         closeButtonContentDescription = intent.getStringExtra(CLOSE_BUTTON_CD_ID)
             ?: getString(R.string.cd_close_button)
+        ocrWrapper.start()
         setContent {
             W3WTheme {
-                val lifecycleOwner = LocalLifecycleOwner.current
-                DisposableEffect(LocalLifecycleOwner.current) {
-                    val observer = LifecycleEventObserver { _, event ->
-                        if (event == Lifecycle.Event.ON_DESTROY) {
-                            ocrWrapper.stop()
-                        }
-                    }
-
-                    lifecycleOwner.lifecycle.addObserver(observer)
-                    onDispose {
-                        lifecycleOwner.lifecycle.removeObserver(observer)
-                    }
-                }
                 // A surface container using the 'background' color from the theme
                 W3WOcrScanner(
                     ocrWrapper,

--- a/lib/src/main/java/com/what3words/ocr/components/ui/MLKitOcrScanActivity.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/ui/MLKitOcrScanActivity.kt
@@ -174,8 +174,11 @@ class MLKitOcrScanActivity : BaseOcrScanActivity() {
         }
     }
 
-    private fun buildMLKit(context: Context, dataProvider: What3WordsAndroidWrapper): W3WOcrMLKitWrapper {
-        val textRecognizer = TextRecognition.getClient(
+    private fun buildMLKit(
+        context: Context,
+        dataProvider: What3WordsAndroidWrapper
+    ): W3WOcrMLKitWrapper {
+        val textRecognizerOptions =
             when (mlKitV2Library) {
                 W3WOcrWrapper.MLKitLibraries.Latin -> TextRecognizerOptions.DEFAULT_OPTIONS
                 W3WOcrWrapper.MLKitLibraries.LatinAndDevanagari -> DevanagariTextRecognizerOptions.Builder()
@@ -194,7 +197,6 @@ class MLKitOcrScanActivity : BaseOcrScanActivity() {
                     "MLKitOcrScanActivity needs a valid MLKit Language Library"
                 )
             }
-        )
-        return W3WOcrMLKitWrapper(context, dataProvider, textRecognizer)
+        return W3WOcrMLKitWrapper(context, dataProvider, textRecognizerOptions)
     }
 }

--- a/samples/src/main/java/com/what3words/ocr/components/sample/ComposeOcrScanPopupSampleActivity.kt
+++ b/samples/src/main/java/com/what3words/ocr/components/sample/ComposeOcrScanPopupSampleActivity.kt
@@ -22,15 +22,19 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions
 import com.google.mlkit.vision.text.devanagari.DevanagariTextRecognizerOptions
@@ -105,6 +109,7 @@ class ComposeOcrScanPopupSampleActivity : ComponentActivity() {
 
                     LaunchedEffect(key1 = viewModel.selectedMLKitLibrary, block = {
                         ocrWrapper = getOcrWrapper()
+                        ocrWrapper.start()
                     })
 
                     AnimatedVisibility(
@@ -193,7 +198,7 @@ class ComposeOcrScanPopupSampleActivity : ComponentActivity() {
     }
 
     private fun getOcrWrapper(): W3WOcrWrapper {
-        val textRecognizer = TextRecognition.getClient(
+        val textRecognizerOptions =
             when (viewModel.selectedMLKitLibrary) {
                 W3WOcrWrapper.MLKitLibraries.Latin -> TextRecognizerOptions.DEFAULT_OPTIONS
                 W3WOcrWrapper.MLKitLibraries.LatinAndDevanagari -> DevanagariTextRecognizerOptions.Builder()
@@ -208,14 +213,13 @@ class ComposeOcrScanPopupSampleActivity : ComponentActivity() {
                 W3WOcrWrapper.MLKitLibraries.LatinAndChinese -> ChineseTextRecognizerOptions.Builder()
                     .build()
             }
-        )
         return W3WOcrMLKitWrapper(
             this,
             What3WordsV3(
                 BuildConfig.W3W_API_KEY,
                 this@ComposeOcrScanPopupSampleActivity
             ),
-            textRecognizer
+            textRecognizerOptions
         )
     }
 


### PR DESCRIPTION
When a wrapper is used in multiple places throughout an app, i.e: multiple screens to check if OCR is enabled for the current language, and want to use a singleton for this, the start and stop will allow to start and stop engines when needed (onCreate of scanning screen and onDestroy of scanning screen), this will allow to clear memory but have the same instance across multiple screens if needed be. 