### PR TITLE
change how dataProvider is used

### DIFF
--- a/lib/src/androidTest/java/com/what3words/ocr/components/W3WOcrMLKitWrapperTest.kt
+++ b/lib/src/androidTest/java/com/what3words/ocr/components/W3WOcrMLKitWrapperTest.kt
@@ -48,12 +48,18 @@ class W3WOcrMLKitWrapperTest {
 
         val latinTextRecognizer = TextRecognizerOptions.DEFAULT_OPTIONS
 
-        mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, latinTextRecognizer)
+        mlKitWrapper = W3WOcrMLKitWrapper(context, latinTextRecognizer)
 
         //when & wait
         mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
-            mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
+            mlKitWrapper.scan(
+                bitmapToScan,
+                what3WordsAndroidWrapper,
+                null,
+                {},
+                {},
+                {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
@@ -84,12 +90,18 @@ class W3WOcrMLKitWrapperTest {
 
         val latinTextRecognizer = TextRecognizerOptions.DEFAULT_OPTIONS
 
-        mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, latinTextRecognizer)
+        mlKitWrapper = W3WOcrMLKitWrapper(context, latinTextRecognizer)
 
         //when & wait
         mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
-            mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
+            mlKitWrapper.scan(
+                bitmapToScan,
+                what3WordsAndroidWrapper,
+                null,
+                {},
+                {},
+                {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
@@ -120,12 +132,18 @@ class W3WOcrMLKitWrapperTest {
             com.what3words.ocr.components.test.R.drawable.simple_valid_hindi_3wa
         )
 
-        mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, devanagariTextRecognizer)
+        mlKitWrapper = W3WOcrMLKitWrapper(context, devanagariTextRecognizer)
 
         //when & wait
         mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
-            mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
+            mlKitWrapper.scan(
+                bitmapToScan,
+                what3WordsAndroidWrapper,
+                null,
+                {},
+                {},
+                {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
@@ -157,12 +175,18 @@ class W3WOcrMLKitWrapperTest {
         )
         val japaneseTextRecognizer = JapaneseTextRecognizerOptions.Builder().build()
 
-        mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, japaneseTextRecognizer)
+        mlKitWrapper = W3WOcrMLKitWrapper(context, japaneseTextRecognizer)
 
         //when & wait
         mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
-            mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
+            mlKitWrapper.scan(
+                bitmapToScan,
+                what3WordsAndroidWrapper,
+                null,
+                {},
+                {},
+                {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
@@ -194,12 +218,18 @@ class W3WOcrMLKitWrapperTest {
         )
         val koreanTextRecognizer = KoreanTextRecognizerOptions.Builder().build()
 
-        mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, koreanTextRecognizer)
+        mlKitWrapper = W3WOcrMLKitWrapper(context, koreanTextRecognizer)
 
         //when & wait
         mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
-            mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
+            mlKitWrapper.scan(
+                bitmapToScan,
+                what3WordsAndroidWrapper,
+                null,
+                {},
+                {},
+                {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }
@@ -231,12 +261,18 @@ class W3WOcrMLKitWrapperTest {
         )
         val chineseTextRecognizer = ChineseTextRecognizerOptions.Builder().build()
 
-        mlKitWrapper = W3WOcrMLKitWrapper(context, what3WordsAndroidWrapper, chineseTextRecognizer)
+        mlKitWrapper = W3WOcrMLKitWrapper(context, chineseTextRecognizer)
 
         //when & wait
         mlKitWrapper.start()
         val scanResult = suspendCoroutine { cont ->
-            mlKitWrapper.scan(bitmapToScan, null, {}, {}, {}) { suggestions, error ->
+            mlKitWrapper.scan(
+                bitmapToScan,
+                what3WordsAndroidWrapper,
+                null,
+                {},
+                {},
+                {}) { suggestions, error ->
                 cont.resume(Pair(suggestions, error))
             }
         }

--- a/lib/src/main/java/com/what3words/ocr/components/models/W3WOcrMLKitWrapper.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/models/W3WOcrMLKitWrapper.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.withContext
  */
 class W3WOcrMLKitWrapper(
     private val context: Context,
-    private val wrapper: What3WordsAndroidWrapper,
     private val recognizerOptions: TextRecognizerOptionsInterface = TextRecognizerOptions.DEFAULT_OPTIONS,
     private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider(),
 ) : W3WOcrWrapper {
@@ -109,6 +108,7 @@ class W3WOcrMLKitWrapper(
 
     override fun scan(
         image: Bitmap,
+        dataProvider: What3WordsAndroidWrapper,
         options: AutosuggestOptions?,
         onScanning: () -> Unit,
         onDetected: () -> Unit,
@@ -129,7 +129,7 @@ class W3WOcrMLKitWrapper(
                 for (possible3wa in What3WordsV3.findPossible3wa(visionText.text.lowercase())) {
                     onDetected.invoke()
                     val autosuggestReq =
-                        wrapper.autosuggest(possible3wa)
+                        dataProvider.autosuggest(possible3wa)
                     if (options != null) autosuggestReq.options(options)
                     val autosuggestRes = autosuggestReq.execute()
                     if (autosuggestRes.isSuccessful) {
@@ -156,10 +156,6 @@ class W3WOcrMLKitWrapper(
 
     override fun executor(): ExecutorService {
         return imageAnalyzerExecutor
-    }
-
-    override fun dataProvider(): What3WordsAndroidWrapper {
-        return wrapper
     }
 
     /**

--- a/lib/src/main/java/com/what3words/ocr/components/models/W3WOcrWrapper.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/models/W3WOcrWrapper.kt
@@ -66,16 +66,17 @@ interface W3WOcrWrapper {
      * Scan [image] [Bitmap] for one or more three word addresses.
      *
      * @param image the [Bitmap] that the scanner should use to find possible three word addresses.
+     * @param dataProvider the [What3WordsAndroidWrapper] that this wrapper will use to validate a three word address could be [What3WordsV3] or [What3WordsSdk].
      * @param options the [AutosuggestOptions] to be applied when validating a possible three word address,
      * i.e: country clipping, check [AutosuggestOptions] for possible filters/clippings.
      * @param onScanning the callback when it starts to scan image for text.
      * @param onDetected the callback when our [findPossible3wa] regex finds possible matches on the scanned text.
      * @param onValidating the callback when we start validating the results of [findPossible3wa] against our API/SDK to check if valid (it will take into account [options] if provided).
-     * @param onFinished the callback with the [OcrScanResult] that can contain a list of [Suggestion] or a [What3WordsError]
-     * @throws [UnsupportedOperationException] if [languageCode] is not supported by this wrapper implementation or this wrapper is language agnostic, i.e [W3WOcrMLKitWrapper].
+     * @param onFinished the callback with a [List] of [Suggestion] or a [What3WordsError] in case an error was found while scanning.
      */
     fun scan(
         image: Bitmap,
+        dataProvider: What3WordsAndroidWrapper,
         options: AutosuggestOptions? = null,
         onScanning: (() -> Unit),
         onDetected: (() -> Unit),
@@ -89,13 +90,6 @@ interface W3WOcrWrapper {
      * @return [ExecutorService] this wrapper runs on.
      */
     fun executor(): ExecutorService
-
-    /**
-     * Get the [What3WordsAndroidWrapper] that this wrapper will use to validate a three word address could be [What3WordsV3] or [What3WordsSdk].
-     *
-     * @return [ExecutorService] this wrapper runs on.
-     */
-    fun dataProvider(): What3WordsAndroidWrapper
 
     /**
      * This method should be called when wrapper needs to be ready to start scanning i.e: Activity.onCreated

--- a/lib/src/main/java/com/what3words/ocr/components/ui/BaseOcrScanActivity.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/ui/BaseOcrScanActivity.kt
@@ -4,10 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
+import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.design.library.ui.models.DisplayUnits
 import com.what3words.design.library.ui.theme.W3WTheme
 import com.what3words.javawrapper.request.AutosuggestOptions
@@ -17,8 +14,8 @@ import com.what3words.ocr.components.models.W3WOcrWrapper
 
 abstract class BaseOcrScanActivity : ComponentActivity() {
 
-    protected lateinit var dataProvider: W3WOcrWrapper.DataProvider
-    protected lateinit var ocrProvider: W3WOcrWrapper.OcrProvider
+    protected lateinit var dataProviderType: W3WOcrWrapper.DataProvider
+    protected lateinit var ocrProviderType: W3WOcrWrapper.OcrProvider
     protected lateinit var displayUnits: DisplayUnits
     protected lateinit var scanStateScanningTitle: String
     protected lateinit var scanStateDetectedTitle: String
@@ -34,6 +31,7 @@ abstract class BaseOcrScanActivity : ComponentActivity() {
     protected var returnCoordinates: Boolean = false
 
     abstract val ocrWrapper: W3WOcrWrapper
+    abstract val dataProvider: What3WordsAndroidWrapper
 
     companion object {
         const val OCR_PROVIDER_ID = "OCR_PROVIDER"
@@ -66,8 +64,8 @@ abstract class BaseOcrScanActivity : ComponentActivity() {
         if (!intent.hasExtra(DATA_PROVIDER_ID) || !intent.hasExtra(OCR_PROVIDER_ID)) {
             throw IllegalAccessException("Missing data provider or ocr provider, please use newInstanceWithApi or newInstanceWithSdk to create a new a specific instance of our OCR Activities.")
         }
-        dataProvider = intent.serializable(DATA_PROVIDER_ID)!!
-        ocrProvider = intent.serializable(OCR_PROVIDER_ID)!!
+        dataProviderType = intent.serializable(DATA_PROVIDER_ID)!!
+        ocrProviderType = intent.serializable(OCR_PROVIDER_ID)!!
         mlKitV2Library = intent.serializable(MLKIT_LIBRARY_ID)
         apiKey = intent.getStringExtra(API_KEY_ID)
         languageCode = intent.getStringExtra(LANGUAGE_CODE_ID)
@@ -92,6 +90,7 @@ abstract class BaseOcrScanActivity : ComponentActivity() {
                 // A surface container using the 'background' color from the theme
                 W3WOcrScanner(
                     ocrWrapper,
+                    dataProvider = dataProvider,
                     options = autosuggestOptions,
                     returnCoordinates = returnCoordinates,
                     displayUnits = displayUnits,

--- a/lib/src/main/java/com/what3words/ocr/components/ui/MLKitOcrScanActivity.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/ui/MLKitOcrScanActivity.kt
@@ -2,7 +2,6 @@ package com.what3words.ocr.components.ui
 
 import android.content.Context
 import android.content.Intent
-import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions
 import com.google.mlkit.vision.text.devanagari.DevanagariTextRecognizerOptions
 import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
@@ -156,16 +155,18 @@ class MLKitOcrScanActivity : BaseOcrScanActivity() {
         }
     }
 
+    override val dataProvider: What3WordsAndroidWrapper by lazy {
+        if (dataProviderType == W3WOcrWrapper.DataProvider.SDK) {
+            What3WordsSdk(this, "")
+        } else {
+            What3WordsV3(apiKey!!, this)
+        }
+    }
+
     override val ocrWrapper: W3WOcrWrapper by lazy {
-        val dataProvider: What3WordsAndroidWrapper =
-            if (dataProvider == W3WOcrWrapper.DataProvider.SDK) {
-                What3WordsSdk(this, "")
-            } else {
-                What3WordsV3(apiKey!!, this)
-            }
-        when (ocrProvider) {
+        when (ocrProviderType) {
             W3WOcrWrapper.OcrProvider.MLKit -> {
-                buildMLKit(this, dataProvider)
+                buildMLKit(this)
             }
 
             else -> {
@@ -175,8 +176,7 @@ class MLKitOcrScanActivity : BaseOcrScanActivity() {
     }
 
     private fun buildMLKit(
-        context: Context,
-        dataProvider: What3WordsAndroidWrapper
+        context: Context
     ): W3WOcrMLKitWrapper {
         val textRecognizerOptions =
             when (mlKitV2Library) {
@@ -197,6 +197,6 @@ class MLKitOcrScanActivity : BaseOcrScanActivity() {
                     "MLKitOcrScanActivity needs a valid MLKit Language Library"
                 )
             }
-        return W3WOcrMLKitWrapper(context, dataProvider, textRecognizerOptions)
+        return W3WOcrMLKitWrapper(context, textRecognizerOptions)
     }
 }

--- a/lib/src/main/java/com/what3words/ocr/components/ui/OcrScanComposable.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/ui/OcrScanComposable.kt
@@ -229,6 +229,7 @@ object W3WOcrScannerDefaults {
 fun W3WOcrScanner(
     wrapper: W3WOcrWrapper,
     modifier: Modifier = Modifier,
+    dataProvider: What3WordsAndroidWrapper,
     options: AutosuggestOptions? = null,
     returnCoordinates: Boolean = false,
     displayUnits: DisplayUnits = DisplayUnits.SYSTEM,
@@ -249,7 +250,7 @@ fun W3WOcrScanner(
     val previewView = remember { PreviewView(context) }
     val scanResultState = remember { ScanResultState() }
     val manager = remember {
-        OcrScanManager(wrapper, options, object : OcrScanManager.OcrScanResultCallback {
+        OcrScanManager(wrapper, dataProvider, options, object : OcrScanResultCallback {
             override fun onScanning() {
                 scanResultState.scanning()
             }
@@ -347,7 +348,7 @@ fun W3WOcrScanner(
                 if (returnCoordinates) {
                     CoroutineScope(Dispatchers.Main).launch {
                         val res = withContext(Dispatchers.IO) {
-                            wrapper.dataProvider().convertToCoordinates(it.words).execute()
+                            dataProvider.convertToCoordinates(it.words).execute()
                         }
                         if (res.isSuccessful) {
                             onSuggestionSelected.invoke(

--- a/lib/src/main/java/com/what3words/ocr/components/ui/OcrScanManager.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/ui/OcrScanManager.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.launch
 @ExperimentalGetImage
 internal class OcrScanManager(
     private val wrapper: W3WOcrWrapper,
+    private val dataProvider: What3WordsAndroidWrapper,
     private val options: AutosuggestOptions? = null,
     private val ocrScanResultCallback: OcrScanResultCallback
 ) {
@@ -81,6 +82,7 @@ internal class OcrScanManager(
                         wrapper.executor(),
                         OcrAnalyzer(
                             wrapper,
+                            dataProvider,
                             options,
                             layoutCoordinates!!,
                             displayMetrics!!,
@@ -141,6 +143,7 @@ internal class OcrScanManager(
     @ExperimentalGetImage
     private class OcrAnalyzer(
         wrapper: W3WOcrWrapper,
+        dataProvider: What3WordsAndroidWrapper,
         options: AutosuggestOptions?,
         layoutCoordinates: LayoutCoordinates,
         displayMetrics: DisplayMetrics,
@@ -149,7 +152,7 @@ internal class OcrScanManager(
     ) :
         ImageAnalysis.Analyzer {
         private val textRecognizer =
-            OcrRecognizer(wrapper, options, layoutCoordinates, displayMetrics)
+            OcrRecognizer(wrapper, dataProvider, options, layoutCoordinates, displayMetrics)
 
         @ExperimentalGetImage
         override fun analyze(imageProxy: ImageProxy) {
@@ -176,6 +179,7 @@ internal class OcrScanManager(
     @ExperimentalGetImage
     private class OcrRecognizer(
         private val wrapper: W3WOcrWrapper,
+        private val dataProvider: What3WordsAndroidWrapper,
         private val options: AutosuggestOptions?,
         private val layoutCoordinates: LayoutCoordinates,
         private val displayMetrics: DisplayMetrics
@@ -214,6 +218,7 @@ internal class OcrScanManager(
                 try {
                     wrapper.scan(
                         bitmapToBeScanned,
+                        dataProvider,
                         options,
                         onScanning = { ocrScanResultCallback.onScanning() },
                         onDetected = { ocrScanResultCallback.onDetected() },

--- a/samples/src/main/java/com/what3words/ocr/components/sample/ComposeOcrScanPopupSampleActivity.kt
+++ b/samples/src/main/java/com/what3words/ocr/components/sample/ComposeOcrScanPopupSampleActivity.kt
@@ -41,6 +41,7 @@ import com.google.mlkit.vision.text.devanagari.DevanagariTextRecognizerOptions
 import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions
 import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.what3words.androidwrapper.What3WordsAndroidWrapper
 import com.what3words.androidwrapper.What3WordsV3
 import com.what3words.design.library.ui.components.NavigationBarScaffold
 import com.what3words.design.library.ui.components.SuggestionWhat3wordsDefaults
@@ -60,6 +61,12 @@ import com.what3words.ocr.components.ui.W3WOcrScannerDefaults
 class ComposeOcrScanPopupSampleActivity : ComponentActivity() {
     private val viewModel: ComposeOcrScanSamplePopupViewModel by viewModels()
     private lateinit var ocrWrapper: W3WOcrWrapper
+    private val dataProvider: What3WordsAndroidWrapper by lazy {
+        What3WordsV3(
+            BuildConfig.W3W_API_KEY,
+            this@ComposeOcrScanPopupSampleActivity
+        )
+    }
 
     private val resultLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -128,6 +135,7 @@ class ComposeOcrScanPopupSampleActivity : ComponentActivity() {
                     ) {
                         W3WOcrScanner(
                             ocrWrapper,
+                            dataProvider = dataProvider,
                             options = options,
                             returnCoordinates = true,
                             //optional if you want to override any string of the scanner composable, to allow localisation and accessibility.
@@ -215,10 +223,6 @@ class ComposeOcrScanPopupSampleActivity : ComponentActivity() {
             }
         return W3WOcrMLKitWrapper(
             this,
-            What3WordsV3(
-                BuildConfig.W3W_API_KEY,
-                this@ComposeOcrScanPopupSampleActivity
-            ),
             textRecognizerOptions
         )
     }


### PR DESCRIPTION
The reasoning for this is that IEngine is deleted mid app lifecycle it's one of the issue we are experiencing in the app, and this makes more sense in general since it's only used inside the composable to c2c and inside scan to autosuggest, it's not needed when component is instantiated