### PR TITLE
Add `CompletableDeferred` to `W3WImageAnalyzer` for async processing completion

### DIFF
--- a/lib/src/main/java/com/what3words/ocr/components/internal/W3WImageAnalysis.kt
+++ b/lib/src/main/java/com/what3words/ocr/components/internal/W3WImageAnalysis.kt
@@ -6,17 +6,25 @@ import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.compose.ui.layout.LayoutCoordinates
 import com.what3words.core.types.common.W3WError
 import com.what3words.core.types.image.W3WImage
+import kotlinx.coroutines.CompletableDeferred
 import java.util.concurrent.ExecutorService
 
 /**
  * Builds an [ImageAnalysis] instance with a [W3WImageAnalyzer] for processing images.
+ *
+ * @param imageAnalyzerExecutor An [ExecutorService] to execute the image analysis on.
+ * @param cropLayoutCoordinates The [LayoutCoordinates] of the crop area view.
+ * @param cameraLayoutCoordinates The [LayoutCoordinates] of the camera view.
+ * @param aspectRatioStrategy The [AspectRatioStrategy] to use for setting the camera resolution.
+ * @param onFrameCaptured A callback invoked when a frame is captured by the camera.
+ * @param onError A callback invoked when an error occurs.
  */
 internal fun buildW3WImageAnalysis(
     imageAnalyzerExecutor: ExecutorService,
     cropLayoutCoordinates: LayoutCoordinates,
     cameraLayoutCoordinates: LayoutCoordinates,
     aspectRatioStrategy: AspectRatioStrategy = AspectRatioStrategy.RATIO_16_9_FALLBACK_AUTO_STRATEGY,
-    onFrameCaptured: (W3WImage) -> Unit,
+    onFrameCaptured: ((W3WImage) -> CompletableDeferred<Unit>),
     onError: (W3WError) -> Unit,
 ): ImageAnalysis {
 


### PR DESCRIPTION
    - Updated W3WImageAnalyzer to accept a CompletableDeferred in onFrameCaptured callback.
    - Clients now use CompletableDeferred to signal the completion of asynchronous image processing.
    - W3WImageAnalyzer waits for the CompletableDeferred to complete before releasing the ImageProxy, preventing premature resource release.
    - The scanImage function in OcrScanManager is no longer blocking the thread.